### PR TITLE
[CHORE] gradle 시큐리티 설정 추가 & 시큐리티 필터체인 기본 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	// jasypt 암호화
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'
 
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/groad/groad_server/global/config/SecurityConfig.java
+++ b/src/main/java/groad/groad_server/global/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package groad.groad_server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors().disable()
+                .csrf().disable()
+                .authorizeRequests()
+                    .anyRequest().permitAll()
+                .and()
+                .formLogin().disable()
+                .httpBasic();
+
+        return http.build();
+
+    }
+}


### PR DESCRIPTION
## Issue
<!--이슈 명 작성-->
- close #4

## Description
<!--이슈 관련 설명-->
시큐리티 설정 추가 & 시큐리티 필터체인 기본 설정 진행했습니다.

[스프링 공식문서](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)에 따르면, Spring Security 5.7 이상의 버전부터는 SecurityFilterChain 사용을 권장하기에, WebSecurityConfigurerAdapter이 아닌 SecurityFilterChain 기본 설정을 진행했습니다. 

## Todo
<!-- - [ ] 진행 예정-->
<!-- - [x] 진행 완료-->
- [x] Gradle 시큐리티  추가
- [x] 시큐리티 필터체인 기본 설정 진행